### PR TITLE
 fix: 친구 삭제 후 재요청 시 unique constraint 에러 수정

### DIFF
--- a/src/main/java/com/idea_l/livecoder/friend/FriendRequestRepository.java
+++ b/src/main/java/com/idea_l/livecoder/friend/FriendRequestRepository.java
@@ -18,4 +18,6 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
     Optional<FriendRequest> findByRequesterAndReceiver(User requester, User receiver);
 
     boolean existsByRequesterAndReceiverAndStatus(User requester, User receiver, RequestStatus status);
+
+    void deleteByRequesterAndReceiver(User requester, User receiver);
 }

--- a/src/main/java/com/idea_l/livecoder/friend/FriendService.java
+++ b/src/main/java/com/idea_l/livecoder/friend/FriendService.java
@@ -169,6 +169,8 @@ public class FriendService {
         Friendship friendship = friendshipRepository.findByUsers(user, friend)
                 .orElseThrow(() -> new IllegalArgumentException("친구 관계가 아닙니다."));
 
+        friendRequestRepository.deleteByRequesterAndReceiver(user, friend);
+        friendRequestRepository.deleteByRequesterAndReceiver(friend, user);
         friendshipRepository.delete(friendship);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,7 @@ logging.level.org.springdoc=debug
 spring.datasource.url=jdbc:mysql://localhost:3306/livecoder
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
+spring.datasource.password=9116qkr!!00
 
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,6 @@ logging.level.org.springdoc=debug
 spring.datasource.url=jdbc:mysql://localhost:3306/livecoder
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
-spring.datasource.password=9116qkr!!00
 
 
 


### PR DESCRIPTION
 - 친구 삭제 후 재요청 시 `friend_requests` 테이블의 unique constraint로 인해 에러 발생하는 버그 수정
  - `deleteFriend()` 시 관련 `friend_requests` 기록 함께 삭제
  - `FriendRequestRepository`에 `deleteByRequesterAndReceiver()` 메서드 추가